### PR TITLE
[feat] server폴더 ci/cd 배포 workflow 구축(#16)

### DIFF
--- a/.github/workflows/server_cicd.yml
+++ b/.github/workflows/server_cicd.yml
@@ -12,10 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install dependencies
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Check out the code
       run: |
         cd server
-        npm install
+        bun install
+        bun run type-check
     
     - name: Create .env file
       run: |
@@ -29,7 +35,7 @@ jobs:
         username: ${{ secrets.REMOTE_USER }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         source: "server/*"
-        target: "/var/www/your_project_directory"
+        target: "/var/www/travely"
         strip_components: 1
 
     - name: Setup environment and start PM2
@@ -39,6 +45,7 @@ jobs:
         username: ${{ secrets.REMOTE_USER }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         script: |
-          cd /var/www/your_project_directory
-          npm install
+          cd /var/www/travely
+          bun install
+          bun run build
           pm2 start ecosystem.config.js --env production

--- a/.github/workflows/server_cicd.yml
+++ b/.github/workflows/server_cicd.yml
@@ -1,0 +1,44 @@
+name: server CI/CD on EC2
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        cd server
+        npm install
+    
+    - name: Create .env file
+      run: |
+          cd server
+          echo "MONGO_URI=${{ secrets.MONGO_URI }}" >> .env
+
+    - name: Deploy to AWS EC2
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.REMOTE_HOST }}
+        username: ${{ secrets.REMOTE_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        source: "server/*"
+        target: "/var/www/your_project_directory"
+        strip_components: 1
+
+    - name: Setup environment and start PM2
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.REMOTE_HOST }}
+        username: ${{ secrets.REMOTE_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        script: |
+          cd /var/www/your_project_directory
+          npm install
+          pm2 start ecosystem.config.js --env production

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+    apps: [{
+      name: "my-express-app",
+      script: "./dist/app.js",
+      instances: "max",
+      exec_mode: "cluster",
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env_file: ".env",
+      env_production: {
+        NODE_ENV: "production",
+        PORT: 3000
+      }
+    }]
+  }

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "User CRUD API with Express and MongoDB",
   "main": "dist/app.js",
   "scripts": {
-    "start": "node dist/app.js",
+    "start": "tsc && node dist/app.js",
     "dev": "nodemon --exec ts-node src/app.ts",
     "build": "tsc",
     "lint": "eslint . --fix",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -37,6 +37,10 @@ async function bootstrap() {
   // 라우터 추가
   app.use('/api/images', imageRoutes);
 
+  app.get('/', (_req, res) => {
+    res.send('Hello World');
+  });
+
   // global Error handler
   app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     console.error(`Error ${err.message} | URL: ${req.url} | Method: ${req.method}`);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -37,6 +37,7 @@ async function bootstrap() {
   // 라우터 추가
   app.use('/api/images', imageRoutes);
 
+  //! 배포 테스트용 라우트
   app.get('/', (_req, res) => {
     res.send('Hello World');
   });


### PR DESCRIPTION

# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

- server 폴더만 ci/cd하는 워크플로우 추가
- **chore: ci/cd workflow 파일추가 (#16)**
- **feat: 서버 ci/cd 워크플로우 추가 (#16)**
- pm2를 사용하여 서버를 실행하고, ec2에서 express 서버가 죽으면 다시 실행하는 워크플로우를 추가했습니다.

## 🔧 변경 사항 요약

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다.

## 📄 추가 정보

추가 정보나 특별한 요청 사항이 있다면 여기에 포함해 주세요.
