### PR TITLE
[feat] 썸네일,퀼노트,태그선택 기능 작업(#52)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "openai-memory": "^1.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-quill-new": "^3.3.3",
         "react-router-dom": "^6.26.2",
         "swiper": "^11.1.14",
         "uuid": "^10.0.0",
@@ -5310,7 +5311,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -5405,7 +5405,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
@@ -6879,10 +6878,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.cond": {
@@ -6897,6 +6914,12 @@
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7850,6 +7873,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7904,6 +7941,42 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-quill-new": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.3.3.tgz",
+      "integrity": "sha512-jxbm1QUJlkuGUpc9/GUgGw5USLHdp43H0M7AufqS3V+zRLng9uqLeVBGjXYqEbUKi8QVOM4SClSV3F7kVNj68w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quill": "~2.0.2"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5.1.0",
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-quill-new/node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/react-quill-new/node_modules/quill": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
+      "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "openai-memory": "^1.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-quill-new": "^3.3.3",
     "react-router-dom": "^6.26.2",
     "swiper": "^11.1.14",
     "uuid": "^10.0.0",

--- a/src/components/addTravel/ChoiceTags.tsx
+++ b/src/components/addTravel/ChoiceTags.tsx
@@ -1,9 +1,12 @@
 import FiledBtn from '@/components/FiledBtn';
 import GrayBack from '@/components/GrayBack';
+import { TagsType } from '@/types/tagType';
 import { css } from '@emotion/react';
+import { useState } from 'react';
 
 const ChoiceTags = () => {
-  const tags = [
+  const [choicedTag, setChoicedTag] = useState<TagsType[]>([]);
+  const tags: TagsType[] = [
     'FOOD',
     'CULTURE',
     'HEALING',
@@ -15,11 +18,23 @@ const ChoiceTags = () => {
     'JEJU',
     'ETC',
   ];
+  const handleTag = (tag: TagsType) => {
+    if (choicedTag.includes(tag)) {
+      setChoicedTag(choicedTag.filter((t) => t !== tag));
+    } else {
+      setChoicedTag([...choicedTag, tag]);
+    }
+  };
   return (
     <GrayBack title={'태그'} padding={true}>
       <div css={tagsWrapper}>
         {tags.map((tag) => (
-          <FiledBtn color={'#d6d6d6'} size={'mdHeight'} key={tag}>
+          <FiledBtn
+            color={choicedTag.includes(tag) ? '#4A95F2' : '#d6d6d6'}
+            size={'mdHeight'}
+            onClick={() => handleTag(tag)}
+            key={tag}
+          >
             # {tag}
           </FiledBtn>
         ))}

--- a/src/components/addTravel/Introduction.tsx
+++ b/src/components/addTravel/Introduction.tsx
@@ -1,10 +1,33 @@
 import GrayBack from '@/components/GrayBack';
 import { css } from '@emotion/react';
+import { useState } from 'react';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
 
 const Introduction = () => {
+  const [value, setValue] = useState('');
+
+  const modules = {
+    toolbar: {
+      container: [
+        [{ header: [1, 2, 3, 4, 5, false] }],
+        [{ align: [] }],
+        ['bold', 'italic', 'underline'],
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        [
+          {
+            color: [],
+          },
+          { background: [] },
+        ],
+        ['image'],
+      ],
+    },
+  };
+
   return (
-    <GrayBack title={'상품 소개'} padding={true}>
-      <textarea css={textbox} placeholder="1,000자 내외로 작성해주세요." />
+    <GrayBack title={'상품 소개'}>
+      <ReactQuill value={value} onChange={setValue} modules={modules} css={textbox} />
     </GrayBack>
   );
 };
@@ -13,7 +36,17 @@ export default Introduction;
 
 const textbox = css`
   width: 100%;
-  height: 180px;
+  height: 300px;
   background-color: transparent;
-  border: none;
+  padding-bottom: 40px;
+  font-size: 16px;
+  & .ql-toolbar.ql-snow {
+    border: none !important;
+  }
+  & .ql-snow {
+    border: none !important;
+    & * {
+      font-size: 16px;
+    }
+  }
 `;

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -1,17 +1,48 @@
 import GrayBack from '@/components/GrayBack';
 import { css } from '@emotion/react';
+import { ImagePlus } from 'lucide-react';
+import { ChangeEvent, useState } from 'react';
 
 const Thumbnail = () => {
+  const [image, setImage] = useState('');
+
+  const handleThumbnailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   return (
     <GrayBack title={'대표 이미지'}>
-      <div css={thumnailSize}></div>
+      <div css={thumnailSize(image)}>
+        <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
+          <ImagePlus size={100} css={{ color: '#fff' }} />
+        </button>
+        <input id="thumbnailUpload" type="file" onChange={(e) => handleThumbnailChange(e)} />
+      </div>
     </GrayBack>
   );
 };
 
 export default Thumbnail;
 
-const thumnailSize = css`
+const thumnailSize = (image: string) => css`
   width: 100%;
   height: 400px;
+  background-image: url(${image});
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-radius: 8px;
+  & button {
+    width: 100%;
+    height: 100%;
+  }
+  & input {
+    display: none;
+  }
 `;

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -6,20 +6,29 @@ import Introduction from '@/components/addTravel/Introduction';
 import Thumbnail from '@/components/addTravel/Thumbnail';
 import GrayBack from '@/components/GrayBack';
 import { css } from '@emotion/react';
+import { useRef } from 'react';
 
 const AddTravel = () => {
+  const titleRef = useRef<HTMLInputElement>(null);
+  const priceRef = useRef<HTMLInputElement>(null);
+
   return (
     <div css={addTravelWrapper}>
       <h1>새로운 여행 계획하기</h1>
       <GrayBack title={'제목'} padding={true}>
-        <input css={noneStyleInput} type="text" placeholder="30자 내외로 작성해주세요." />
+        <input
+          ref={titleRef}
+          css={noneStyleInput}
+          type="text"
+          placeholder="30자 내외로 작성해주세요."
+        />
       </GrayBack>
       <Thumbnail />
       <Introduction />
       <Course />
       <ChoiceTags />
       <GrayBack title={'가격'} price={true} padding={true}>
-        <input css={noneStyleInput} type="number" placeholder="0" />
+        <input ref={priceRef} css={noneStyleInput} type="number" placeholder="0" />
         <span css={{ marginRight: '5px' }}>원</span>
         <span css={{ fontSize: '14px' }}>/ 1인</span>
       </GrayBack>
@@ -47,4 +56,8 @@ const noneStyleInput = css`
   width: 100%;
   background-color: transparent;
   border: none;
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    display: none;
+  }
 `;

--- a/src/types/tagType.ts
+++ b/src/types/tagType.ts
@@ -21,3 +21,15 @@ export type TagPath =
   | 'kdrama'
   | 'jeju'
   | 'etc';
+
+export type TagsType =
+  | 'FOOD'
+  | 'CULTURE'
+  | 'HEALING'
+  | 'NATURE'
+  | 'SPORTS'
+  | 'FESTIVAL'
+  | 'K-POP'
+  | 'K-DRAMA'
+  | 'JEJU'
+  | 'ETC';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

썸네일,퀼노트,태그선택 기능 작업

## 🔧 변경 사항 요약

- 썸네일 추가 가능
- 기존 퀼노트('react-quill') 지원되지 않는 DOMNodeInserted 이벤트 이슈로 인해 'react-quill-new'로 설치하여 적용
- 태그 선택 가능
- 가격 input number type 기본 ui 제거 (어제 피드백)
- 제목, 가격 ref 적용

## 📸 스크린샷 (선택 사항)

<img width="584" alt="스크린샷 2024-10-15 오후 1 26 04" src="https://github.com/user-attachments/assets/9f6914aa-88c4-4dfe-85a2-316af32795c8">

## 📄 추가 정보

추가 정보나 특별한 요청 사항이 있다면 여기에 포함해 주세요.
