### PR TITLE
[feat] 여행 소개 첨부이미지 4개로 제한 및 업로드된 링크 받아오기

### DIFF
--- a/src/components/addTravel/FloatingMenu.tsx
+++ b/src/components/addTravel/FloatingMenu.tsx
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 import { CircleMinus, CirclePlus } from 'lucide-react';
 import { useState } from 'react';
 
-export const FloatingMenu = () => {
+interface FloatingMenu {
+  onClick: () => void;
+}
+
+export const FloatingMenu = ({ onClick }: FloatingMenu) => {
   const [openSections, setOpenSections] = useState<string[]>([]);
 
   const toggleSection = (section: string) => {
@@ -75,7 +79,7 @@ export const FloatingMenu = () => {
 
       <BottomButtons>
         <TempSaveButton>임시저장</TempSaveButton>
-        <CompleteButton>작성완료</CompleteButton>
+        <CompleteButton onClick={onClick}>작성완료</CompleteButton>
       </BottomButtons>
     </MenuContainer>
   );

--- a/src/components/addTravel/Introduction.tsx
+++ b/src/components/addTravel/Introduction.tsx
@@ -1,11 +1,35 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import GrayBack from '@/components/GrayBack';
+import useImageStore from '@/stores/useImageStore';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactQuill from 'react-quill-new';
 import 'react-quill-new/dist/quill.snow.css';
 
 const Introduction = () => {
+  const [imgLimit, setImgLimit] = useState(false);
   const [value, setValue] = useState('');
+  const setIntroSrcs = useImageStore((state) => state.setIntroSrcs);
+
+  useEffect(() => {
+    const regex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g;
+    let match;
+    const newSrcs: string[] = [];
+    while ((match = regex.exec(value)) !== null) {
+      newSrcs.push(match[1]);
+    }
+    if (newSrcs.length > 4) {
+      const excessImgSrc = newSrcs[4];
+      const newValue = value.replace(`<img src="${excessImgSrc}">`, '');
+      setValue(newValue);
+      newSrcs.pop();
+      setImgLimit(true);
+      setTimeout(() => {
+        setImgLimit(false);
+      }, 3000);
+    }
+    setIntroSrcs(newSrcs);
+  }, [value]);
 
   const modules = {
     toolbar: {
@@ -28,6 +52,9 @@ const Introduction = () => {
   return (
     <GrayBack title={'상품 소개'}>
       <ReactQuill value={value} onChange={setValue} modules={modules} css={textbox} />
+      {imgLimit ? (
+        <p css={{ fontSize: '14px', color: '#ff2020' }}>이미지는 최대 4장까지 첨부 가능합니다.</p>
+      ) : null}
     </GrayBack>
   );
 };
@@ -36,7 +63,7 @@ export default Introduction;
 
 const textbox = css`
   width: 100%;
-  height: 300px;
+  height: 400px;
   background-color: transparent;
   padding-bottom: 40px;
   font-size: 16px;

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -1,17 +1,50 @@
 import GrayBack from '@/components/GrayBack';
+import useImageStore from '@/stores/useImageStore';
 import { css } from '@emotion/react';
+import axios from 'axios';
 import { ImagePlus } from 'lucide-react';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 
 const Thumbnail = () => {
-  const [image, setImage] = useState('');
+  const thumbnail = useImageStore((state) => state.images.thumbnail);
+  const setThumbnail = useImageStore((state) => state.setThumbnail);
 
-  const handleThumbnailChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleThumbnailChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
       const reader = new FileReader();
-      reader.onloadend = () => {
-        setImage(reader.result as string);
+
+      reader.onloadend = async () => {
+        const imageData = reader.result as string;
+        setThumbnail(imageData);
+
+        //
+        const [mimePart, base64Data] = imageData.split(',');
+        const byteString = atob(base64Data);
+
+        const arrayBuffer = new Uint8Array(byteString.length);
+        for (let i = 0; i < byteString.length; i++) {
+          arrayBuffer[i] = byteString.charCodeAt(i);
+        }
+
+        const blobFile = new Blob([arrayBuffer], { type: mimePart.split(':')[1].split(';')[0] });
+        const formData = new FormData();
+        formData.append('images', blobFile);
+
+        try {
+          const response = await axios.post(
+            'http://3.37.101.147:3000/api/images/upload',
+            formData,
+            {
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+          );
+          console.log('업로드 성공:', response.data.imageUrls[0]);
+        } catch (error) {
+          console.error('업로드 오류:', error);
+        }
       };
       reader.readAsDataURL(file);
     }
@@ -19,7 +52,7 @@ const Thumbnail = () => {
 
   return (
     <GrayBack title={'대표 이미지'}>
-      <div css={thumnailSize(image)}>
+      <div css={thumnailSize(thumbnail)}>
         <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
           <ImagePlus size={100} css={{ color: '#fff' }} />
         </button>
@@ -31,10 +64,10 @@ const Thumbnail = () => {
 
 export default Thumbnail;
 
-const thumnailSize = (image: string) => css`
+const thumnailSize = (thumbnail: string) => css`
   width: 100%;
   height: 400px;
-  background-image: url(${image});
+  background-image: url(${thumbnail});
   background-repeat: no-repeat;
   background-size: cover;
   border-radius: 8px;

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -1,7 +1,6 @@
 import GrayBack from '@/components/GrayBack';
 import useImageStore from '@/stores/useImageStore';
 import { css } from '@emotion/react';
-import axios from 'axios';
 import { ImagePlus } from 'lucide-react';
 import { ChangeEvent } from 'react';
 
@@ -17,34 +16,6 @@ const Thumbnail = () => {
       reader.onloadend = async () => {
         const imageData = reader.result as string;
         setThumbnail(imageData);
-
-        //
-        const [mimePart, base64Data] = imageData.split(',');
-        const byteString = atob(base64Data);
-
-        const arrayBuffer = new Uint8Array(byteString.length);
-        for (let i = 0; i < byteString.length; i++) {
-          arrayBuffer[i] = byteString.charCodeAt(i);
-        }
-
-        const blobFile = new Blob([arrayBuffer], { type: mimePart.split(':')[1].split(';')[0] });
-        const formData = new FormData();
-        formData.append('images', blobFile);
-
-        try {
-          const response = await axios.post(
-            'http://3.37.101.147:3000/api/images/upload',
-            formData,
-            {
-              headers: {
-                'Content-Type': 'multipart/form-data',
-              },
-            },
-          );
-          console.log('업로드 성공:', response.data.imageUrls[0]);
-        } catch (error) {
-          console.error('업로드 오류:', error);
-        }
       };
       reader.readAsDataURL(file);
     }

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+interface UseImageUploadPM {
+  formData: FormData;
+  enabled: boolean;
+}
+
+const useImageUpload = ({ formData, enabled }: UseImageUploadPM) => {
+  return useQuery({
+    queryKey: ['imageUpload', formData],
+    queryFn: async () => {
+      try {
+        const response = await axios.post('http://3.37.101.147:3000/api/images/upload', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
+        return response.data.imageUrls;
+      } catch (error) {
+        console.error('업로드 오류:', error);
+      }
+    },
+    enabled,
+  });
+};
+export default useImageUpload;

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -7,11 +7,38 @@ import Introduction from '@/components/addTravel/Introduction';
 import Thumbnail from '@/components/addTravel/Thumbnail';
 import GrayBack from '@/components/GrayBack';
 import { css } from '@emotion/react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
+import useImageStore from '@/stores/useImageStore';
+import useImageUpload from '@/hooks/useImageUpload';
 
 const AddTravel = () => {
+  const [enabled, setEnabled] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const priceRef = useRef<HTMLInputElement>(null);
+  const images = useImageStore((state) => state.images);
+  const formData = new FormData();
+  const { data: uploadedImages } = useImageUpload({ formData, enabled });
+
+  const handleUpload = () => {
+    if (images.thumbnail === '') return;
+    setEnabled(true);
+    const uploadSrc = [images.thumbnail].concat(images.introSrcs); // 0번째는 무조건 썸네일url입니다
+    uploadSrc.forEach((src) => {
+      const [mimeString, base64Data] = src.split(',');
+      const byteString = atob(base64Data);
+      const ab = new Uint8Array(byteString.length);
+      for (let i = 0; i < byteString.length; i++) {
+        ab[i] = byteString.charCodeAt(i);
+      }
+      const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
+      formData.append('images', file, `image-${Math.random()}.jpg`);
+    });
+    if (uploadedImages) {
+      // uploadedImages 이미지 배포된 링크들 (0번째 썸네일, 1번째부터는 intro에 삽입한 이미지)
+      setEnabled(false);
+      console.log(uploadedImages);
+    }
+  };
 
   return (
     <div css={pageLayoutWrapper}>
@@ -40,7 +67,7 @@ const AddTravel = () => {
         <Details title={'이용안내'} />
         <Details title={'FAQ'} />
       </div>
-      <FloatingMenu />
+      <FloatingMenu onClick={handleUpload} />
     </div>
   );
 };

--- a/src/stores/useImageStore.ts
+++ b/src/stores/useImageStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+interface ImageStore {
+  thumbnail: string;
+  introSrcs: string[];
+}
+
+interface State {
+  images: ImageStore;
+}
+
+interface Action {
+  setThumbnail: (thumbnail: string) => void;
+  setIntroSrcs: (introSrcs: string[]) => void;
+  resetImages: () => void;
+}
+
+const useImageStore = create<State & Action>((set) => ({
+  images: {
+    thumbnail: '',
+    introSrcs: [],
+  },
+  setThumbnail: (thumbnail: string) =>
+    set((state) => {
+      return { images: { ...state.images, thumbnail } };
+    }),
+  setIntroSrcs: (introSrcs: string[]) =>
+    set((state) => {
+      return { images: { ...state.images, introSrcs } };
+    }),
+  resetImages: () =>
+    set({
+      images: {
+        thumbnail: '',
+        introSrcs: [],
+      },
+    }),
+}));
+
+export default useImageStore;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

여행 소개 첨부이미지 4개로 제한 및 업로드된 링크 받아오기

## 🔧 변경 사항 요약

- 썸네일, 여행소개 이미지 src 전역으로 관리
- Introduction.tsx 여행소개에 첨부되는 이미지 4개로 제한 -> 4개이상이면 이미지 지우고 하단에 경고문구 3초간 뜨게해둠

- FloatingMenu에 있는 작성완료 버튼 누를시 useImageUpload실행 -> 반환되는 링크(uploadedImages) 오면 나머지 저장API연결하시면 될듯합니다. AddTravel.tsx에 주석으로 달아두었습니다.

