### PR TITLE
[feat] 관리페이지 route수정 & API요청 hook 작성

### DIFF
--- a/src/components/myPage/MyPageContainer.tsx
+++ b/src/components/myPage/MyPageContainer.tsx
@@ -23,13 +23,9 @@ const MyPageContainerLayout = () => {
 };
 
 const myPageLayout = (managePage: boolean) => css`
-  display: flex;
+  display: ${managePage ? 'block' : 'flex'};
   gap: 60px;
   position: relative;
-  ${managePage &&
-  `
-    display: block;
-  `}
 `;
 
 export default MyPageContainerLayout;

--- a/src/components/myPage/MyPageContainer.tsx
+++ b/src/components/myPage/MyPageContainer.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate, Outlet } from 'react-router-dom';
 const MyPageContainerLayout = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const managePage = location.pathname.startsWith('/my-page/my-created-travel/manage-my-travel/');
 
   useEffect(() => {
     if (location.pathname === '/my-page/') {
@@ -14,19 +15,21 @@ const MyPageContainerLayout = () => {
   }, [location.pathname, navigate]);
 
   return (
-    <div css={myPageLayout}>
-      <MyPageSideMenu />
-      <section>
-        <Outlet />
-      </section>
+    <div css={myPageLayout(managePage)}>
+      {managePage ? null : <MyPageSideMenu />}
+      <Outlet />
     </div>
   );
 };
 
-const myPageLayout = css`
+const myPageLayout = (managePage: boolean) => css`
   display: flex;
   gap: 60px;
   position: relative;
+  ${managePage &&
+  `
+    display: block;
+  `}
 `;
 
 export default MyPageContainerLayout;

--- a/src/hooks/useManageTravelData.ts
+++ b/src/hooks/useManageTravelData.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+interface useManageTravelDataPM {
+  travelId: string;
+  enabled: boolean;
+}
+
+const useManageTravelData = ({ travelId, enabled }: useManageTravelDataPM) => {
+  return useQuery({
+    queryKey: ['manageTravel', travelId],
+    queryFn: async () => {
+      try {
+        const res = await axios.get(`/api/v1/travels/manage-my-travel/${travelId}`);
+        return res.data;
+      } catch (error) {
+        console.error('관리할 여행 데이터 로드 실패:', error);
+      }
+    },
+    enabled,
+  });
+};
+export default useManageTravelData;

--- a/src/layouts/Auth.tsx
+++ b/src/layouts/Auth.tsx
@@ -9,7 +9,7 @@ import useLoginStore from '@/stores/useLoginStore';
 import * as Dialog from '@radix-ui/react-dialog';
 import useModalStore from '@/stores/useModalStore';
 import { X } from 'lucide-react';
-import logo from 'src/assets/logo-black.png';
+import logo from '/src/assets/logo-black.png';
 import googleLogo from '/src/assets/google-icon.svg';
 import kakaoLogo from '/src/assets/kakao-icon.svg';
 import basicProfile from '/src/assets/basicProfile.png';

--- a/src/layouts/Breadcrumb.tsx
+++ b/src/layouts/Breadcrumb.tsx
@@ -13,6 +13,7 @@ const breadcrumbsMap: { [key: string]: string } = {
   'my-travel-list': '참여한 여행',
   'my-account': '계정',
   'my-created-travel': '내가 만든 여행',
+  'manage-my-travel': '내 여행 관리',
   'my-travel': '내 여행',
   'travel-detail': '여행 상세',
 };

--- a/src/pages/ManageMyTravel.tsx
+++ b/src/pages/ManageMyTravel.tsx
@@ -5,25 +5,31 @@ import TravelTeam from '@/components/manageMyTravel/TravelTeam';
 import TravelManageHeader from '@/components/manageMyTravel/TravelManageHeader';
 import teamDataFilter from '@/utils/teamDataFilter';
 import usePageStore from '@/stores/usePageStore';
+import { useParams } from 'react-router-dom';
 
 const ManageMyTravel = () => {
   const [tab, setTab] = useState(true);
   const setMultiPagination = usePageStore((state) => state.setMultiPagination);
+  const { travelId } = useParams();
 
   useEffect(() => {
     const filterData = teamDataFilter(data, tab ? 'ongoing' : 'completed');
     setMultiPagination(filterData.length);
   }, [tab]);
 
+  if (data.id !== travelId) {
+    return;
+  }
+
   return (
-    <section css={{ color: '#333' }}>
+    <div css={{ color: '#333' }}>
       <TravelManageHeader travelData={data} tab={tab} setTab={setTab} />
       {tab ? (
         <TravelTeam data={teamDataFilter(data, 'ongoing')} />
       ) : (
         <TravelTeam data={teamDataFilter(data, 'completed')} />
       )}
-    </section>
+    </div>
   );
 };
 

--- a/src/pages/MyCreatedTravel.tsx
+++ b/src/pages/MyCreatedTravel.tsx
@@ -1,6 +1,7 @@
 import MyTravelContent from '@/components/myTravel/MyTravelContent';
 import MyTravelTab from '@/components/myTravel/MyTravelTab';
 import { useTabStore } from '@/stores/useTabStore';
+import { Outlet } from 'react-router-dom';
 
 const MyCreatedTravel = () => {
   const { selectedTab } = useTabStore();
@@ -9,6 +10,7 @@ const MyCreatedTravel = () => {
     <div>
       <MyTravelTab />
       {selectedTab === '내가 만든 여행' && <MyTravelContent />}
+      <Outlet />
     </div>
   );
 };

--- a/src/pages/MyCreatedTravel.tsx
+++ b/src/pages/MyCreatedTravel.tsx
@@ -5,11 +5,16 @@ import { Outlet } from 'react-router-dom';
 
 const MyCreatedTravel = () => {
   const { selectedTab } = useTabStore();
+  const managePage = location.pathname.startsWith('/my-page/my-created-travel/manage-my-travel/');
 
   return (
     <div>
-      <MyTravelTab />
-      {selectedTab === '내가 만든 여행' && <MyTravelContent />}
+      {managePage ? null : (
+        <>
+          <MyTravelTab />
+          {selectedTab === '내가 만든 여행' && <MyTravelContent />}
+        </>
+      )}
       <Outlet />
     </div>
   );

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -70,6 +70,12 @@ const router = createBrowserRouter([
                     <MyCreatedTravel />
                   </div>
                 ),
+                children: [
+                  {
+                    path: 'manage-my-travel/:travelId',
+                    element: <ManageMyTravel />,
+                  },
+                ],
               },
               {
                 path: 'my-reviews',
@@ -92,10 +98,6 @@ const router = createBrowserRouter([
                 ),
               },
             ],
-          },
-          {
-            path: 'manage-my-travel',
-            element: <ManageMyTravel />,
           },
           {
             path: 'add-travel',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

관리페이지 route수정 & API요청 hook 작성

## 🔧 변경 사항 요약

- 관리페이지 route수정
    - /my-page/my-created-travel/manage-my-travel/:travelId
    - 위의 경로일때 마이페이지에 고정된 네브바, 상위컴포넌트 null 처리
   
- API요청 hook 작성 (useManageTravelData.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자가 생성한 여행 관리 기능 추가: `manage-my-travel/:travelId` 경로에서 여행 세부 정보를 관리할 수 있는 새로운 하위 경로 추가.
	- `MyPage`에서 사이드 메뉴의 조건부 렌더링 구현.
	- URL 매개변수를 활용하여 여행 ID를 추출하고, ID 비교를 통해 렌더링 로직 개선.
	- 새로운 커스텀 훅 `useManageTravelData` 도입으로 여행 데이터 가져오기 기능 추가.
	- 새로운 빵 부스러기 경로 추가: '내 여행 관리'로 표시되는 `manage-my-travel` 경로.

- **버그 수정**
	- `managePage` 변수에 따라 컴포넌트의 렌더링 로직 수정.

- **문서화**
	- 코드의 일부 구조 및 스타일 수정에 대한 설명 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->