### PR TITLE
[feat] "만나는장소"에도 이미지업로드기능추가

### DIFF
--- a/src/components/addTravel/Details.tsx
+++ b/src/components/addTravel/Details.tsx
@@ -71,7 +71,7 @@ const Details = ({ title }: DetailsProps) => {
               <CirclePlus size={24} />
             </button>
           </div>
-          <Thumbnail thumbnailComponent={false} />
+          <Thumbnail type="meetingSpace" />
         </>
       ) : (
         <>

--- a/src/components/addTravel/Details.tsx
+++ b/src/components/addTravel/Details.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import useFieldStore, { Options } from '@/stores/useFieldStore';
 import { useRef, useState } from 'react';
 import DetailsList from '@/components/addTravel/DetailsList';
+import Thumbnail from '@/components/addTravel/Thumbnail';
 
 interface DetailsProps {
   title: string;
@@ -70,6 +71,7 @@ const Details = ({ title }: DetailsProps) => {
               <CirclePlus size={24} />
             </button>
           </div>
+          <Thumbnail thumbnailComponent={false} />
         </>
       ) : (
         <>

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -4,9 +4,14 @@ import { css } from '@emotion/react';
 import { ImagePlus } from 'lucide-react';
 import { ChangeEvent } from 'react';
 
-const Thumbnail = () => {
+interface ThumnailProps {
+  thumbnailComponent: boolean;
+}
+
+const Thumbnail = ({ thumbnailComponent }: ThumnailProps) => {
   const thumbnail = useImageStore((state) => state.images.thumbnail);
   const setThumbnail = useImageStore((state) => state.setThumbnail);
+  const setMeetingSpace = useImageStore((state) => state.setMeetingSpace);
 
   const handleThumbnailChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -15,14 +20,18 @@ const Thumbnail = () => {
 
       reader.onloadend = async () => {
         const imageData = reader.result as string;
-        setThumbnail(imageData);
+        if (thumbnailComponent) {
+          setThumbnail(imageData);
+        } else {
+          setMeetingSpace(imageData);
+        }
       };
       reader.readAsDataURL(file);
     }
   };
 
   return (
-    <GrayBack title={'대표 이미지'}>
+    <GrayBack title={thumbnailComponent ? '대표 이미지' : '만나는장소'}>
       <div css={thumnailSize(thumbnail)}>
         <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
           <ImagePlus size={100} css={{ color: '#fff' }} />

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -4,11 +4,11 @@ import { css } from '@emotion/react';
 import { ImagePlus } from 'lucide-react';
 import { ChangeEvent } from 'react';
 
-interface ThumnailProps {
-  thumbnailComponent: boolean;
+interface ThumbnailProps {
+  type: 'thumbnail' | 'meetingSpace';
 }
 
-const Thumbnail = ({ thumbnailComponent }: ThumnailProps) => {
+const Thumbnail = ({ type }: ThumbnailProps) => {
   const thumbnail = useImageStore((state) => state.images.thumbnail);
   const setThumbnail = useImageStore((state) => state.setThumbnail);
   const setMeetingSpace = useImageStore((state) => state.setMeetingSpace);
@@ -20,7 +20,7 @@ const Thumbnail = ({ thumbnailComponent }: ThumnailProps) => {
 
       reader.onloadend = async () => {
         const imageData = reader.result as string;
-        if (thumbnailComponent) {
+        if (type === 'thumbnail') {
           setThumbnail(imageData);
         } else {
           setMeetingSpace(imageData);
@@ -31,8 +31,8 @@ const Thumbnail = ({ thumbnailComponent }: ThumnailProps) => {
   };
 
   return (
-    <GrayBack title={thumbnailComponent ? '대표 이미지' : '만나는장소'}>
-      <div css={thumnailSize(thumbnail)}>
+    <GrayBack title={type === 'thumbnail' ? '대표 이미지' : '만나는장소'}>
+      <div css={thumbnailSize(thumbnail)}>
         <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
           <ImagePlus size={100} css={{ color: '#fff' }} />
         </button>
@@ -44,7 +44,7 @@ const Thumbnail = ({ thumbnailComponent }: ThumnailProps) => {
 
 export default Thumbnail;
 
-const thumnailSize = (thumbnail: string) => css`
+const thumbnailSize = (thumbnail: string) => css`
   width: 100%;
   height: 400px;
   background-image: url(${thumbnail});

--- a/src/layouts/Auth.tsx
+++ b/src/layouts/Auth.tsx
@@ -9,10 +9,10 @@ import useLoginStore from '@/stores/useLoginStore';
 import * as Dialog from '@radix-ui/react-dialog';
 import useModalStore from '@/stores/useModalStore';
 import { X } from 'lucide-react';
-import logo from 'src/assets/logo-black.png';
-import googleLogo from '/src/assets/google-icon.svg';
-import kakaoLogo from '/src/assets/kakao-icon.svg';
-import basicProfile from '/src/assets/basicProfile.png';
+import logo from '@/assets/logo-black.png';
+import googleLogo from '@/assets/google-icon.svg';
+import kakaoLogo from '@/assets/kakao-icon.svg';
+import basicProfile from '@/assets/basicProfile.png';
 
 const Auth: React.FC<{ light?: boolean }> = ({ light = false }) => {
   const [user, setUser] = useState<FirebaseUser | null>(null);

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -60,7 +60,7 @@ const AddTravel = () => {
             placeholder="30자 내외로 작성해주세요."
           />
         </GrayBack>
-        <Thumbnail thumbnailComponent={true} />
+        <Thumbnail type="thumbnail" />
         <Introduction />
         <Course />
         <ChoiceTags />

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -60,7 +60,7 @@ const AddTravel = () => {
             placeholder="30자 내외로 작성해주세요."
           />
         </GrayBack>
-        <Thumbnail />
+        <Thumbnail thumbnailComponent={true} />
         <Introduction />
         <Course />
         <ChoiceTags />

--- a/src/stores/useImageStore.ts
+++ b/src/stores/useImageStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 interface ImageStore {
   thumbnail: string;
+  meetingSpace: string;
   introSrcs: string[];
 }
 
@@ -12,17 +13,23 @@ interface State {
 interface Action {
   setThumbnail: (thumbnail: string) => void;
   setIntroSrcs: (introSrcs: string[]) => void;
+  setMeetingSpace: (meetingSpace: string) => void;
   resetImages: () => void;
 }
 
 const useImageStore = create<State & Action>((set) => ({
   images: {
     thumbnail: '',
+    meetingSpace: '',
     introSrcs: [],
   },
   setThumbnail: (thumbnail: string) =>
     set((state) => {
       return { images: { ...state.images, thumbnail } };
+    }),
+  setMeetingSpace: (meetingSpace: string) =>
+    set((state) => {
+      return { images: { ...state.images, meetingSpace } };
     }),
   setIntroSrcs: (introSrcs: string[]) =>
     set((state) => {
@@ -33,6 +40,7 @@ const useImageStore = create<State & Action>((set) => ({
       images: {
         thumbnail: '',
         introSrcs: [],
+        meetingSpace: '',
       },
     }),
 }));


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

 "만나는장소"에도 이미지업로드기능추가

## 🔧 변경 사항 요약

 - "만나는장소"에도 이미지업로드기능추가 : 동일한 기능인 Thumbnail 컴포넌트 활용
 - imageStore에 meetingSpace추가
 - 이미지업로드API수정된 이후 API요청 코드 수정 할 예정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- `Details` 컴포넌트에 `Thumbnail` 컴포넌트 추가, '이용안내' 제목일 때 조건부로 렌더링.
	- `Thumbnail` 컴포넌트에 `type` prop 추가, 이미지 처리 방식 변경.
	- `AddTravel` 페이지에서 `Thumbnail` 컴포넌트 호출 방식 업데이트.

- **버그 수정**
	- `ImageStore`에 `meetingSpace` 상태 추가 및 관련 메서드 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->