### PR TITLE
[feat] addTravel에서 사용한 컴포넌트 재활용하여 addForFindGuide 페이지 작업(#101)

### DIFF
--- a/src/components/addTravel/Course.tsx
+++ b/src/components/addTravel/Course.tsx
@@ -13,8 +13,10 @@ const Course = () => {
 
   const handleAddCourse = () => {
     if (courseRef.current) {
-      addField('courseList', courseRef.current.value);
-      courseRef.current.value = '';
+      if (courseRef.current.value.trim() !== '') {
+        addField('courseList', courseRef.current.value);
+        courseRef.current.value = '';
+      }
     }
   };
 
@@ -49,7 +51,7 @@ const Course = () => {
           onKeyDown={(e) => handleKeyDown(e)}
           onCompositionStart={() => setIsComposing(true)}
           onCompositionEnd={() => setIsComposing(false)}
-          placeholder="40자 내외로 여행 코스를 작성해주세요."
+          placeholder="40자 내외로 여행 코스를 추가해주세요."
         />
         <button css={plusBtn} onClick={handleAddCourse}>
           <CirclePlus size={24} />

--- a/src/components/addTravel/Details.tsx
+++ b/src/components/addTravel/Details.tsx
@@ -30,7 +30,7 @@ const Details = ({ title }: DetailsProps) => {
   const addFieldPmCheck = () => {
     if (option === 'faqs') {
       if (newFieldRef.current && answer.current) {
-        if (newFieldRef.current.value !== '' && answer.current.value !== '') {
+        if (newFieldRef.current.value.trim() !== '' && answer.current.value.trim() !== '') {
           addField(option, newFieldRef.current.value, answer.current.value);
           newFieldRef.current.value = '';
           answer.current.value = '';
@@ -38,8 +38,10 @@ const Details = ({ title }: DetailsProps) => {
       }
     } else {
       if (newFieldRef.current) {
-        addField(option, newFieldRef.current.value);
-        newFieldRef.current.value = '';
+        if (newFieldRef.current.value.trim() !== '') {
+          addField(option, newFieldRef.current.value);
+          newFieldRef.current.value = '';
+        }
       }
     }
   };

--- a/src/components/addTravel/DetailsList.tsx
+++ b/src/components/addTravel/DetailsList.tsx
@@ -88,6 +88,9 @@ const list = css`
       transform: scale(1.2);
     }
   }
+  & * {
+    display: block;
+  }
 `;
 
 const faqlist = css`
@@ -108,6 +111,9 @@ const faqlist = css`
     & p {
       font-weight: 700;
     }
+  }
+  & * {
+    display: block;
   }
 `;
 

--- a/src/components/addTravel/FloatingMenu.tsx
+++ b/src/components/addTravel/FloatingMenu.tsx
@@ -1,75 +1,106 @@
-// FloatingMenu.tsx
+import useSectionsStore from '@/stores/useSectionsStore';
 import styled from '@emotion/styled';
 import { CircleMinus, CirclePlus } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
 
 interface FloatingMenuProps {
-  openSections: string[];
-  toggleSection: (section: string) => void;
   onClick: () => void;
 }
 
-const FloatingMenu = ({ openSections, toggleSection, onClick }: FloatingMenuProps) => {
+const FloatingMenu = ({ onClick }: FloatingMenuProps) => {
+  const sections = useSectionsStore((state) => state.sections);
+  const setOpenSection = useSectionsStore((state) => state.setOpenSection);
+  const location = useLocation();
   return (
-    <MenuContainer>
-      <MenuItem>
-        <span>제목</span>
-      </MenuItem>
-      <MenuItem>
-        <span>대표 이미지</span>
-      </MenuItem>
-      <MenuItem>
-        <span>상품소개</span>
-      </MenuItem>
-      <MenuItem>
-        <span>코스</span>
-      </MenuItem>
-      <MenuItem>
-        <span>태그</span>
-      </MenuItem>
-      <MenuItem>
-        <span>예약 생성</span>
-      </MenuItem>
-      <MenuItem>
-        <span>가격</span>
-      </MenuItem>
+    <MenuContainer location={location.pathname}>
+      {location.pathname === '/add-for-find-guide' ? (
+        <>
+          <MenuItem>
+            <span>제목</span>
+          </MenuItem>
+          <MenuItem isOpen={sections.includes('대표이미지')}>
+            <span>대표 이미지</span>
+            <ToggleIcon
+              onClick={() => setOpenSection('대표이미지')}
+              isOpen={sections.includes('대표이미지')}
+            >
+              {sections.includes('대표이미지') ? (
+                <CircleMinus size={22} />
+              ) : (
+                <CirclePlus size={22} />
+              )}
+            </ToggleIcon>
+          </MenuItem>
+          <MenuItem>
+            <span>상품 소개</span>
+          </MenuItem>
+          <MenuItem>
+            <span>일정 및 팀 추가</span>
+          </MenuItem>
+        </>
+      ) : (
+        <>
+          <MenuItem>
+            <span>제목</span>
+          </MenuItem>
+          <MenuItem>
+            <span>대표 이미지</span>
+          </MenuItem>
+          <MenuItem>
+            <span>상품소개</span>
+          </MenuItem>
+          <MenuItem>
+            <span>코스</span>
+          </MenuItem>
+          <MenuItem>
+            <span>태그</span>
+          </MenuItem>
+          <MenuItem>
+            <span>예약 생성</span>
+          </MenuItem>
+          <MenuItem>
+            <span>가격</span>
+          </MenuItem>
 
-      <MenuItem isOpen={openSections.includes('포함내용')}>
-        <span>포함내용</span>
-        <ToggleIcon
-          onClick={() => toggleSection('포함내용')}
-          isOpen={openSections.includes('포함내용')}
-        >
-          {openSections.includes('포함내용') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
-        </ToggleIcon>
-      </MenuItem>
-      <MenuItem isOpen={openSections.includes('미포함내용')}>
-        <span>미포함내용</span>
-        <ToggleIcon
-          onClick={() => toggleSection('미포함내용')}
-          isOpen={openSections.includes('미포함내용')}
-        >
-          {openSections.includes('미포함내용') ? (
-            <CircleMinus size={22} />
-          ) : (
-            <CirclePlus size={22} />
-          )}
-        </ToggleIcon>
-      </MenuItem>
-      <MenuItem isOpen={openSections.includes('이용안내')}>
-        <span>이용안내</span>
-        <ToggleIcon
-          onClick={() => toggleSection('이용안내')}
-          isOpen={openSections.includes('이용안내')}
-        >
-          {openSections.includes('이용안내') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
-        </ToggleIcon>
-      </MenuItem>
-      <MenuItem isOpen={openSections.includes('FAQ')}>
-        <span>FAQ</span>
-        <ToggleIcon onClick={() => toggleSection('FAQ')} isOpen={openSections.includes('FAQ')}>
-          {openSections.includes('FAQ') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
-        </ToggleIcon>
-      </MenuItem>
+          <MenuItem isOpen={sections.includes('포함내용')}>
+            <span>포함내용</span>
+            <ToggleIcon
+              onClick={() => setOpenSection('포함내용')}
+              isOpen={sections.includes('포함내용')}
+            >
+              {sections.includes('포함내용') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
+            </ToggleIcon>
+          </MenuItem>
+          <MenuItem isOpen={sections.includes('미포함내용')}>
+            <span>미포함내용</span>
+            <ToggleIcon
+              onClick={() => setOpenSection('미포함내용')}
+              isOpen={sections.includes('미포함내용')}
+            >
+              {sections.includes('미포함내용') ? (
+                <CircleMinus size={22} />
+              ) : (
+                <CirclePlus size={22} />
+              )}
+            </ToggleIcon>
+          </MenuItem>
+          <MenuItem isOpen={sections.includes('이용안내')}>
+            <span>이용안내</span>
+            <ToggleIcon
+              onClick={() => setOpenSection('이용안내')}
+              isOpen={sections.includes('이용안내')}
+            >
+              {sections.includes('이용안내') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
+            </ToggleIcon>
+          </MenuItem>
+          <MenuItem isOpen={sections.includes('FAQ')}>
+            <span>FAQ</span>
+            <ToggleIcon onClick={() => setOpenSection('FAQ')} isOpen={sections.includes('FAQ')}>
+              {sections.includes('FAQ') ? <CircleMinus size={22} /> : <CirclePlus size={22} />}
+            </ToggleIcon>
+          </MenuItem>
+        </>
+      )}
 
       <BottomButtons>
         <TempSaveButton>임시저장</TempSaveButton>
@@ -81,12 +112,11 @@ const FloatingMenu = ({ openSections, toggleSection, onClick }: FloatingMenuProp
 
 export default FloatingMenu;
 
-// 스타일 정의
-const MenuContainer = styled.div`
+const MenuContainer = styled.div<{ location: string }>`
   position: sticky;
   top: 20px;
   min-width: 240px;
-  height: 520px;
+  height: ${({ location }) => (location === '/add-for-find-guide' ? '260px' : '520px')};
   padding: 16px;
   border: 1px solid #d2d2d2;
   border-radius: 8px;

--- a/src/components/addTravel/FloatingMenu.tsx
+++ b/src/components/addTravel/FloatingMenu.tsx
@@ -11,8 +11,11 @@ const FloatingMenu = ({ onClick }: FloatingMenuProps) => {
   const sections = useSectionsStore((state) => state.sections);
   const setOpenSection = useSectionsStore((state) => state.setOpenSection);
   const location = useLocation();
+
+  const menuHeight = location.pathname === '/add-for-find-guide' ? '260px' : '520px';
+
   return (
-    <MenuContainer location={location.pathname}>
+    <MenuContainer menuHeight={menuHeight}>
       {location.pathname === '/add-for-find-guide' ? (
         <>
           <MenuItem>
@@ -112,11 +115,11 @@ const FloatingMenu = ({ onClick }: FloatingMenuProps) => {
 
 export default FloatingMenu;
 
-const MenuContainer = styled.div<{ location: string }>`
+const MenuContainer = styled.div<{ menuHeight: string }>`
   position: sticky;
   top: 20px;
   min-width: 240px;
-  height: ${({ location }) => (location === '/add-for-find-guide' ? '260px' : '520px')};
+  height: ${({ menuHeight }) => menuHeight};
   padding: 16px;
   border: 1px solid #d2d2d2;
   border-radius: 8px;

--- a/src/components/addTravel/ScheduleTeam.tsx
+++ b/src/components/addTravel/ScheduleTeam.tsx
@@ -3,6 +3,7 @@ import useFieldStore, { Schedule } from '@/stores/useFieldStore';
 import { CirclePlus, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import Team from '@/components/Team';
+import { useLocation } from 'react-router-dom';
 
 const ScheduleTeam = () => {
   const [isComposing, setIsComposing] = useState(false);
@@ -12,6 +13,7 @@ const ScheduleTeam = () => {
   const startDateRef = useRef<HTMLInputElement>(null);
   const endDateRef = useRef<HTMLInputElement>(null);
   const membersRef = useRef<HTMLSelectElement>(null);
+  const location = useLocation();
 
   const handleAddSchedule = () => {
     if (fields.scheduleList.length >= 4) {
@@ -19,14 +21,20 @@ const ScheduleTeam = () => {
       return;
     }
     if (startDateRef.current && endDateRef.current && membersRef.current) {
-      const newSchedule: Schedule = {
-        date: `${startDateRef.current.value} ~ ${endDateRef.current.value}`,
-        members: membersRef.current.value,
-      };
-      addField('scheduleList', newSchedule);
-      startDateRef.current.value = '';
-      endDateRef.current.value = '';
-      membersRef.current.value = '';
+      if (
+        startDateRef.current.value.trim() !== '' &&
+        endDateRef.current.value.trim() !== '' &&
+        membersRef.current.value.trim() !== ''
+      ) {
+        const newSchedule: Schedule = {
+          date: `${startDateRef.current.value} ~ ${endDateRef.current.value}`,
+          members: membersRef.current.value,
+        };
+        addField('scheduleList', newSchedule);
+        startDateRef.current.value = '';
+        endDateRef.current.value = '';
+        membersRef.current.value = '';
+      }
     }
   };
 
@@ -54,54 +62,56 @@ const ScheduleTeam = () => {
           </li>
         ))}
       </ul>
-      <div css={scheduleAddWrapper}>
-        <div css={inputRowWrapper}>
-          <label css={labelStyle}>일정</label>
-          <input
-            css={smallTextBox}
-            ref={startDateRef}
-            type="date"
-            placeholder="시작 날짜"
-            onKeyDown={(e) => handleKeyDown(e)}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-          />
-          <span css={tilde}>~</span>
-          <input
-            css={smallTextBox}
-            ref={endDateRef}
-            type="date"
-            placeholder="종료 날짜"
-            onKeyDown={(e) => handleKeyDown(e)}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-          />
-        </div>
-        <div css={inputRowWithButtonWrapper}>
+      {location.pathname === '/add-for-find-guide' && fields.scheduleList.length < 1 && (
+        <div css={scheduleAddWrapper}>
           <div css={inputRowWrapper}>
-            <label css={labelStyle}>모집인원</label>
-            <select
+            <label css={labelStyle}>일정</label>
+            <input
               css={smallTextBox}
-              ref={membersRef}
-              defaultValue=""
+              ref={startDateRef}
+              type="date"
+              placeholder="시작 날짜"
+              onKeyDown={(e) => handleKeyDown(e)}
               onCompositionStart={() => setIsComposing(true)}
               onCompositionEnd={() => setIsComposing(false)}
-            >
-              <option value="" disabled>
-                본인제외
-              </option>
-              {[1, 2, 3, 4, 5, 6, 7].map((num) => (
-                <option key={num} value={num}>
-                  {num}명
-                </option>
-              ))}
-            </select>
+            />
+            <span css={tilde}>~</span>
+            <input
+              css={smallTextBox}
+              ref={endDateRef}
+              type="date"
+              placeholder="종료 날짜"
+              onKeyDown={(e) => handleKeyDown(e)}
+              onCompositionStart={() => setIsComposing(true)}
+              onCompositionEnd={() => setIsComposing(false)}
+            />
           </div>
-          <button css={plusBtn} onClick={handleAddSchedule}>
-            <CirclePlus size={24} />
-          </button>
+          <div css={inputRowWithButtonWrapper}>
+            <div css={inputRowWrapper}>
+              <label css={labelStyle}>모집인원</label>
+              <select
+                css={smallTextBox}
+                ref={membersRef}
+                defaultValue=""
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+              >
+                <option value="" disabled>
+                  본인제외
+                </option>
+                {[1, 2, 3, 4, 5, 6, 7].map((num) => (
+                  <option key={num} value={num}>
+                    {num}명
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button css={plusBtn} onClick={handleAddSchedule}>
+              <CirclePlus size={24} />
+            </button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };
@@ -125,7 +135,7 @@ const scheduleList = css`
   border-radius: 8px;
   background-color: #f8f8f8;
   margin-bottom: 10px;
-  padding: 10px 20px;
+  padding: 20px;
   & button {
     color: #888;
     margin-left: 10px;
@@ -133,6 +143,14 @@ const scheduleList = css`
     :hover {
       transform: scale(1.2);
     }
+    * {
+      display: block;
+    }
+  }
+  & div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 `;
 

--- a/src/hooks/useGetImageUrls.ts
+++ b/src/hooks/useGetImageUrls.ts
@@ -6,7 +6,7 @@ interface UseImageUploadPM {
   enabled: boolean;
 }
 
-const useImageUpload = ({ formData, enabled }: UseImageUploadPM) => {
+const useGetImageUrls = ({ formData, enabled }: UseImageUploadPM) => {
   return useQuery({
     queryKey: ['imageUpload', formData],
     queryFn: async () => {
@@ -24,4 +24,4 @@ const useImageUpload = ({ formData, enabled }: UseImageUploadPM) => {
     enabled,
   });
 };
-export default useImageUpload;
+export default useGetImageUrls;

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,0 +1,24 @@
+import useGetImageUrls from '@/hooks/useGetImageUrls';
+import { ImageStore } from '@/stores/useImageStore';
+import prepareImageUpload from '@/utils/prepareImageUpload';
+import { useState } from 'react';
+
+const useHandleImageUpload = (images: ImageStore) => {
+  const [enabled, setEnabled] = useState(false);
+  const formData = new FormData();
+  const { data: uploadedImages } = useGetImageUrls({ formData, enabled });
+
+  const uploadImages = () => {
+    if (images.thumbnail === '') return;
+
+    setEnabled(true);
+    prepareImageUpload(images, formData);
+    if (uploadedImages) {
+      setEnabled(false);
+      console.log(uploadedImages);
+    }
+  };
+
+  return { uploadImages };
+};
+export default useHandleImageUpload;

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,21 +1,30 @@
 import useGetImageUrls from '@/hooks/useGetImageUrls';
 import { ImageStore } from '@/stores/useImageStore';
 import prepareImageUpload from '@/utils/prepareImageUpload';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const useHandleImageUpload = (images: ImageStore) => {
   const [enabled, setEnabled] = useState(false);
   const formData = new FormData();
   const { data: uploadedImages } = useGetImageUrls({ formData, enabled });
 
+  useEffect(() => {
+    return () => {
+      setEnabled(false);
+    };
+  }, []);
+
   const uploadImages = () => {
     if (images.thumbnail === '') return;
-
-    setEnabled(true);
-    prepareImageUpload(images, formData);
-    if (uploadedImages) {
-      setEnabled(false);
-      console.log(uploadedImages);
+    try {
+      setEnabled(true);
+      prepareImageUpload(images, formData);
+      if (uploadedImages) {
+        setEnabled(false);
+        console.log(uploadedImages);
+      }
+    } catch (error) {
+      console.warn(error);
     }
   };
 

--- a/src/pages/AddForFindGuide.tsx
+++ b/src/pages/AddForFindGuide.tsx
@@ -1,0 +1,40 @@
+import FloatingMenu from '@/components/addTravel/FloatingMenu';
+import Introduction from '@/components/addTravel/Introduction';
+import ScheduleTeam from '@/components/addTravel/ScheduleTeam';
+import Thumbnail from '@/components/addTravel/Thumbnail';
+import GrayBack from '@/components/GrayBack';
+import useHandleImageUpload from '@/hooks/useHandleImageUpload';
+import { addTravelWrapper, noneStyleInput, pageLayoutWrapper } from '@/pages/AddTravel';
+import useImageStore from '@/stores/useImageStore';
+import useSectionsStore from '@/stores/useSectionsStore';
+import { useRef } from 'react';
+
+const AddForFindGuide = () => {
+  const sections = useSectionsStore((state) => state.sections);
+  const images = useImageStore((state) => state.images);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const { uploadImages } = useHandleImageUpload(images);
+
+  return (
+    <div css={pageLayoutWrapper}>
+      <div css={addTravelWrapper}>
+        <h1>가이드를 찾습니다</h1>
+        <GrayBack title={'제목'} padding={true}>
+          <input
+            ref={titleRef}
+            css={noneStyleInput}
+            type="text"
+            placeholder="30자 내외로 작성해주세요."
+          />
+        </GrayBack>
+        {sections.includes('대표이미지') && <Thumbnail type="thumbnail" />}
+        <Introduction />
+        <ScheduleTeam />
+      </div>
+
+      <FloatingMenu onClick={uploadImages} />
+    </div>
+  );
+};
+
+export default AddForFindGuide;

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -5,48 +5,20 @@ import Details from '@/components/addTravel/Details';
 import Thumbnail from '@/components/addTravel/Thumbnail';
 import GrayBack from '@/components/GrayBack';
 import { css } from '@emotion/react';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import Introduction from '@/components/addTravel/Introduction';
 import useImageStore from '@/stores/useImageStore';
-import useImageUpload from '@/hooks/useImageUpload';
 import FloatingMenu from '@/components/addTravel/FloatingMenu';
+import useSectionsStore from '@/stores/useSectionsStore';
+import useHandleImageUpload from '@/hooks/useHandleImageUpload';
 
 const AddTravel = () => {
-  const [enabled, setEnabled] = useState(false);
-  const [openSections, setOpenSections] = useState<string[]>([]);
-
+  const sections = useSectionsStore((state) => state.sections);
+  const images = useImageStore((state) => state.images);
   const titleRef = useRef<HTMLInputElement>(null);
   const priceRef = useRef<HTMLInputElement>(null);
-  const images = useImageStore((state) => state.images);
 
-  const toggleSection = (section: string) => {
-    setOpenSections((prev) =>
-      prev.includes(section) ? prev.filter((item) => item !== section) : [...prev, section],
-    );
-  };
-  const formData = new FormData();
-  const { data: uploadedImages } = useImageUpload({ formData, enabled });
-
-  const handleUpload = () => {
-    if (images.thumbnail === '') return;
-    setEnabled(true);
-    const uploadSrc = [images.thumbnail].concat(images.introSrcs); // 0번째는 무조건 썸네일url입니다
-    uploadSrc.forEach((src) => {
-      const [mimeString, base64Data] = src.split(',');
-      const byteString = atob(base64Data);
-      const ab = new Uint8Array(byteString.length);
-      for (let i = 0; i < byteString.length; i++) {
-        ab[i] = byteString.charCodeAt(i);
-      }
-      const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
-      formData.append('images', file, `image-${Math.random()}.jpg`);
-    });
-    if (uploadedImages) {
-      // uploadedImages 이미지 배포된 링크들 (0번째 썸네일, 1번째부터는 intro에 삽입한 이미지)
-      setEnabled(false);
-      console.log(uploadedImages);
-    }
-  };
+  const { uploadImages } = useHandleImageUpload(images);
 
   return (
     <div css={pageLayoutWrapper}>
@@ -71,25 +43,20 @@ const AddTravel = () => {
           <span css={{ fontSize: '14px' }}>/ 1인</span>
         </GrayBack>
 
-        {openSections.includes('포함내용') && <Details title={'포함내용'} />}
-        {openSections.includes('미포함내용') && <Details title={'미포함내용'} />}
-        {openSections.includes('이용안내') && <Details title={'이용안내'} />}
-        {openSections.includes('FAQ') && <Details title={'FAQ'} />}
+        {sections.includes('포함내용') && <Details title={'포함내용'} />}
+        {sections.includes('미포함내용') && <Details title={'미포함내용'} />}
+        {sections.includes('이용안내') && <Details title={'이용안내'} />}
+        {sections.includes('FAQ') && <Details title={'FAQ'} />}
       </div>
 
-      <FloatingMenu
-        openSections={openSections}
-        toggleSection={toggleSection}
-        onClick={handleUpload}
-      />
+      <FloatingMenu onClick={uploadImages} />
     </div>
   );
 };
 
 export default AddTravel;
 
-// 스타일 정의
-const addTravelWrapper = css`
+export const addTravelWrapper = css`
   position: relative;
   width: 680px;
   margin-right: 200px;
@@ -109,7 +76,7 @@ export const noneStyleInput = css`
   }
 `;
 
-const pageLayoutWrapper = css`
+export const pageLayoutWrapper = css`
   display: flex;
   position: relative;
 `;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -13,6 +13,7 @@ import MyCreatedTravel from '@/pages/MyCreatedTravel'; // 내가 만든 여행 �
 import TravelDetail from '@/pages/TravelDetail';
 import Bookmark from '@/pages/Bookmark';
 import MyAccount from '@/pages/MyAccount';
+import AddForFindGuide from '@/pages/AddForFindGuide';
 
 const PATH = {
   HOME: '/',
@@ -102,6 +103,10 @@ const router = createBrowserRouter([
           {
             path: 'add-travel',
             element: <AddTravel />,
+          },
+          {
+            path: 'add-for-find-guide',
+            element: <AddForFindGuide />,
           },
         ],
       },

--- a/src/stores/useImageStore.ts
+++ b/src/stores/useImageStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-interface ImageStore {
+export interface ImageStore {
   thumbnail: string;
   meetingSpace: string;
   introSrcs: string[];

--- a/src/stores/useSectionsStore.ts
+++ b/src/stores/useSectionsStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+interface State {
+  sections: string[];
+}
+
+interface Action {
+  setOpenSection: (section: string) => void;
+}
+
+const useSectionsStore = create<State & Action>((set) => ({
+  sections: [],
+  setOpenSection: (section: string) =>
+    set((state: State) => {
+      if (state.sections.includes(section)) {
+        const filterSections = state.sections.filter((item) => item !== section);
+        return { sections: filterSections };
+      } else {
+        return { sections: [...state.sections, section] };
+      }
+    }),
+}));
+
+export default useSectionsStore;

--- a/src/utils/prepareImageUpload.ts
+++ b/src/utils/prepareImageUpload.ts
@@ -1,0 +1,20 @@
+import { ImageStore } from '@/stores/useImageStore';
+
+const prepareImageUpload = (images: ImageStore, formData: FormData) => {
+  const uploadSrc = [images.thumbnail].concat(images.introSrcs);
+
+  uploadSrc.forEach((src) => {
+    const [mimeString, base64Data] = src.split(',');
+    const byteString = atob(base64Data);
+    const ab = new Uint8Array(byteString.length);
+
+    for (let i = 0; i < byteString.length; i++) {
+      ab[i] = byteString.charCodeAt(i);
+    }
+
+    const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
+    formData.append('images', file, `image-${Math.random()}.jpg`);
+  });
+};
+
+export default prepareImageUpload;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

addTravel에서 사용한 컴포넌트 재활용하여 addForFindGuide 페이지 작업

## 🔧 변경 사항 요약

- 필드추가되는 컴포넌트의 ref값이 빈값으로 추가되지 않도록 적용: ...ref.current.value.trim() !== '' 
- 필드에 X아이콘 가운데로 오도록 스타일수정
- floatingMenu.tsx location 값으로 조건부 렌더링
- 글작성페이지에서 각각 사용 가능하도록 floatingMenu section 전역상태로 관리 -> useSectionsStore.ts 생성
- 다른 페이지에서도 재사용 할 수 있도록 이미지업로드 유틸 & 훅으로 분리
- 가이드구해요 글작성 페이지에서는 일정추가 1개만 가능하여 해당 페이지 일 시 갯수 제한함
- 기존 useImageUpload.ts 파일명을 useGetImageUrls.ts로 수정

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/165bc70d-36ce-4649-b0e7-0246b39b8ed2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 입력 필드의 공백 검증을 강화하여 빈 값이 추가되지 않도록 개선.
  - 새로운 이미지 업로드 관리 훅 `useHandleImageUpload` 추가.
  - 새로운 페이지 컴포넌트 `AddForFindGuide` 추가 및 라우팅 설정.
  - `FloatingMenu` 컴포넌트의 상태 관리 방식을 중앙 집중식으로 변경.

- **버그 수정**
  - 입력 필드의 공백 체크 로직 수정.

- **스타일**
  - `DetailsList` 컴포넌트의 CSS 스타일 개선.
  - `ScheduleTeam` 컴포넌트의 레이아웃 및 스타일 업데이트.

- **문서화**
  - `ImageStore` 인터페이스의 가시성 변경 (공개로 수정).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->