### PR TITLE
[feat] 이미지업로드 key,value형태로 수정

### DIFF
--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -24,8 +24,11 @@ const Thumbnail = ({ type }: ThumbnailProps) => {
         }, 3000);
         return;
       }
-      if (!file.type.startsWith('image/')) {
-        setErrMessage('이미지 파일만 업로드 가능합니다.');
+      if (
+        !file.type.startsWith('image/') ||
+        !['image/jpeg', 'image/png', 'image/jpg'].includes(file.type)
+      ) {
+        setErrMessage('jpeg, png, jpg 형식의 이미지 파일만 업로드 가능합니다.');
         setTimeout(() => {
           setErrMessage('');
         }, 3000);

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -2,13 +2,14 @@ import GrayBack from '@/components/GrayBack';
 import useImageStore from '@/stores/useImageStore';
 import { css } from '@emotion/react';
 import { ImagePlus } from 'lucide-react';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 interface ThumbnailProps {
   type: 'thumbnail' | 'meetingSpace';
 }
 
 const Thumbnail = ({ type }: ThumbnailProps) => {
+  const [errMessage, setErrMessage] = useState('');
   const thumbnail = useImageStore((state) => state.images.thumbnail);
   const setThumbnail = useImageStore((state) => state.setThumbnail);
   const setMeetingSpace = useImageStore((state) => state.setMeetingSpace);
@@ -16,8 +17,22 @@ const Thumbnail = ({ type }: ThumbnailProps) => {
   const handleThumbnailChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
-      const reader = new FileReader();
+      if (file.size > 5 * 1024 * 1024) {
+        setErrMessage('파일 크기는 5MB 이하여야 합니다.');
+        setTimeout(() => {
+          setErrMessage('');
+        }, 3000);
+        return;
+      }
+      if (!file.type.startsWith('image/')) {
+        setErrMessage('이미지 파일만 업로드 가능합니다.');
+        setTimeout(() => {
+          setErrMessage('');
+        }, 3000);
+        return;
+      }
 
+      const reader = new FileReader();
       reader.onloadend = async () => {
         const imageData = reader.result as string;
         if (type === 'thumbnail') {
@@ -31,14 +46,17 @@ const Thumbnail = ({ type }: ThumbnailProps) => {
   };
 
   return (
-    <GrayBack title={type === 'thumbnail' ? '대표 이미지' : '만나는장소'}>
-      <div css={thumbnailSize(thumbnail)}>
-        <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
-          <ImagePlus size={100} css={{ color: '#fff' }} />
-        </button>
-        <input id="thumbnailUpload" type="file" onChange={(e) => handleThumbnailChange(e)} />
-      </div>
-    </GrayBack>
+    <>
+      <GrayBack title={type === 'thumbnail' ? '대표 이미지' : '만나는장소'}>
+        <div css={thumbnailSize(thumbnail)}>
+          <button onClick={() => document.getElementById('thumbnailUpload')?.click()}>
+            <ImagePlus size={100} css={{ color: '#fff' }} />
+          </button>
+          <input id="thumbnailUpload" type="file" onChange={(e) => handleThumbnailChange(e)} />
+        </div>
+      </GrayBack>
+      <p css={{ fontSize: '14px', color: '#ff2020' }}>{errMessage}</p>
+    </>
   );
 };
 
@@ -50,6 +68,7 @@ const thumbnailSize = (thumbnail: string) => css`
   background-image: url(${thumbnail});
   background-repeat: no-repeat;
   background-size: cover;
+  background-position: center;
   border-radius: 8px;
   & button {
     width: 100%;

--- a/src/hooks/useGetImageUrls.ts
+++ b/src/hooks/useGetImageUrls.ts
@@ -6,24 +6,32 @@ interface UseImageUploadPM {
   enabled: boolean;
 }
 
+const S3_URL = import.meta.env.VITE_S3_URL;
+if (!S3_URL) {
+  throw new Error('VITE_S3_URL 환경 변수가 설정되지 않았습니다.');
+}
 const useGetImageUrls = ({ preparedImageData, enabled }: UseImageUploadPM) => {
   return useQuery({
     queryKey: ['imageUpload', preparedImageData],
     queryFn: async () => {
       if (preparedImageData) {
         try {
-          const response = await axios.post(
-            `${import.meta.env.VITE_S3_URL}/api/images/upload`,
-            preparedImageData,
-            {
-              headers: {
-                'Content-Type': 'multipart/form-data',
-              },
+          const response = await axios.post(`${S3_URL}/api/images/upload`, preparedImageData, {
+            headers: {
+              'Content-Type': 'multipart/form-data',
             },
-          );
-          return response.data.imageUrls;
+          });
+          const imageUrls = response.data.imageUrls;
+          if (!imageUrls) {
+            throw new Error('이미지 URL을 받아오는데 실패했습니다.');
+          }
+          return imageUrls;
         } catch (error) {
-          console.error('업로드 오류:', error);
+          throw new Error(
+            error instanceof Error
+              ? `이미지 업로드 실패: ${error.message}`
+              : '이미지 업로드 중 알 수 없는 오류가 발생했습니다.',
+          );
         }
       }
     },

--- a/src/hooks/useGetImageUrls.ts
+++ b/src/hooks/useGetImageUrls.ts
@@ -2,23 +2,29 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
 interface UseImageUploadPM {
-  formData: FormData;
+  preparedImageData: FormData | null;
   enabled: boolean;
 }
 
-const useGetImageUrls = ({ formData, enabled }: UseImageUploadPM) => {
+const useGetImageUrls = ({ preparedImageData, enabled }: UseImageUploadPM) => {
   return useQuery({
-    queryKey: ['imageUpload', formData],
+    queryKey: ['imageUpload', preparedImageData],
     queryFn: async () => {
-      try {
-        const response = await axios.post('http://3.37.101.147:3000/api/images/upload', formData, {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        });
-        return response.data.imageUrls;
-      } catch (error) {
-        console.error('업로드 오류:', error);
+      if (preparedImageData) {
+        try {
+          const response = await axios.post(
+            `${import.meta.env.VITE_S3_URL}/api/images/upload`,
+            preparedImageData,
+            {
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+          );
+          return response.data.imageUrls;
+        } catch (error) {
+          console.error('업로드 오류:', error);
+        }
       }
     },
     enabled,

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,27 +1,23 @@
 import useGetImageUrls from '@/hooks/useGetImageUrls';
 import { ImageStore } from '@/stores/useImageStore';
 import prepareImageUpload from '@/utils/prepareImageUpload';
-import { useEffect, useState } from 'react';
+import { useRef } from 'react';
 
 const useHandleImageUpload = (images: ImageStore) => {
-  const [enabled, setEnabled] = useState(false);
-  const formData = new FormData();
-  const { data: uploadedImages } = useGetImageUrls({ formData, enabled });
-
-  useEffect(() => {
-    return () => {
-      setEnabled(false);
-    };
-  }, []);
+  const preparedImageData = useRef<FormData | null>(null);
+  const { data: uploadedImageUrls } = useGetImageUrls({
+    preparedImageData: preparedImageData.current,
+    enabled: !!preparedImageData,
+  });
 
   const uploadImages = () => {
     if (images.thumbnail === '') return;
     try {
-      setEnabled(true);
-      prepareImageUpload(images, formData);
-      if (uploadedImages) {
-        setEnabled(false);
-        console.log(uploadedImages);
+      preparedImageData.current = prepareImageUpload(images);
+      if (uploadedImageUrls) {
+        preparedImageData.current = null;
+        // console.log(uploadedImageUrls);
+        return uploadedImageUrls;
       }
     } catch (error) {
       console.warn(error);

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -7,7 +7,7 @@ const useHandleImageUpload = (images: ImageStore) => {
   const preparedImageData = useRef<FormData | null>(null);
   const { data: uploadedImageUrls } = useGetImageUrls({
     preparedImageData: preparedImageData.current,
-    enabled: !!preparedImageData,
+    enabled: !!preparedImageData.current,
   });
 
   const uploadImages = () => {
@@ -20,6 +20,7 @@ const useHandleImageUpload = (images: ImageStore) => {
         return uploadedImageUrls;
       }
     } catch (error) {
+      preparedImageData.current = null;
       console.warn(error);
     }
   };

--- a/src/utils/prepareImageUpload.ts
+++ b/src/utils/prepareImageUpload.ts
@@ -1,20 +1,36 @@
 import { ImageStore } from '@/stores/useImageStore';
 
-const prepareImageUpload = (images: ImageStore, formData: FormData) => {
-  const uploadSrc = [images.thumbnail].concat(images.introSrcs);
+const addImageToFormData = (formData: FormData, type: string, base64String: string) => {
+  base64String = base64String || '';
+  if (!base64String) return;
 
-  uploadSrc.forEach((src) => {
-    const [mimeString, base64Data] = src.split(',');
-    const byteString = atob(base64Data);
-    const ab = new Uint8Array(byteString.length);
+  const [mimeString, base64Data] = base64String.split(',');
+  const byteString = atob(base64Data);
+  const ab = new Uint8Array(byteString.length);
 
-    for (let i = 0; i < byteString.length; i++) {
-      ab[i] = byteString.charCodeAt(i);
+  for (let i = 0; i < byteString.length; i++) {
+    ab[i] = byteString.charCodeAt(i);
+  }
+
+  const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
+  formData.append(type, file, `${type}-${Math.random()}.jpg`);
+};
+
+const prepareImageUpload = (images: ImageStore) => {
+  const formData = new FormData();
+  if (images.thumbnail) {
+    addImageToFormData(formData, 'thumbnail', images.thumbnail);
+  }
+  if (images.meetingSpace) {
+    addImageToFormData(formData, 'meetingSpace', images.meetingSpace);
+  }
+  images.introSrcs.forEach((src, index) => {
+    if (src) {
+      addImageToFormData(formData, `introSrcs[${index}]`, src);
     }
-
-    const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
-    formData.append('images', file, `image-${Math.random()}.jpg`);
   });
+
+  return formData;
 };
 
 export default prepareImageUpload;

--- a/src/utils/prepareImageUpload.ts
+++ b/src/utils/prepareImageUpload.ts
@@ -4,6 +4,10 @@ const addImageToFormData = (formData: FormData, type: string, base64String: stri
   base64String = base64String || '';
   if (!base64String) return;
 
+  if (!/^data:image\/(jpeg|png|gif);base64,/.test(base64String)) {
+    throw new Error('유효하지 않은 이미지 형식입니다.');
+  }
+
   const [mimeString, base64Data] = base64String.split(',');
   const byteString = atob(base64Data);
   const ab = new Uint8Array(byteString.length);

--- a/src/utils/prepareImageUpload.ts
+++ b/src/utils/prepareImageUpload.ts
@@ -4,10 +4,6 @@ const addImageToFormData = (formData: FormData, type: string, base64String: stri
   base64String = base64String || '';
   if (!base64String) return;
 
-  if (!/^data:image\/(jpeg|png|gif);base64,/.test(base64String)) {
-    throw new Error('유효하지 않은 이미지 형식입니다.');
-  }
-
   const [mimeString, base64Data] = base64String.split(',');
   const byteString = atob(base64Data);
   const ab = new Uint8Array(byteString.length);
@@ -17,7 +13,10 @@ const addImageToFormData = (formData: FormData, type: string, base64String: stri
   }
 
   const file = new Blob([ab], { type: mimeString.split(':')[1].split(';')[0] });
-  formData.append(type, file, `${type}-${Math.random()}.jpg`);
+  const mimeType = mimeString.split(':')[1].split(';')[0];
+  const extension = mimeType.split('/')[1];
+  const timestamp = new Date().getTime();
+  formData.append(type, file, `${type}-${timestamp}.${extension}`);
 };
 
 const prepareImageUpload = (images: ImageStore) => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간단히 설명해 주세요]**

## 📋 작업 세부 사항

이미지업로드 api요청 코드 수정

## 🔧 변경 사항 요약

- 이미지업로드 api요청 훅, utill 코드 수정
- 정상적인 요청이 가는지는 서버api 수정되고 확인 가능함
- s3 서버 url env로 뺐음
- "썸네일"이랑 "만나는장소" 이미지: 파일 크기 5MB, 이미지 파일만 업로드 가능하도록 제한



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 파일 업로드 처리 로직 개선 및 오류 메시지 관리 추가.
	- 사용자에게 파일 업로드 피드백을 제공하는 기능 추가.

- **버그 수정**
	- 파일 크기 및 형식 검증 로직 추가로 잘못된 파일 업로드 방지.
	- API 호출 시 오류 처리 로직 강화.

- **문서화**
	- 이미지 업로드를 위한 헬퍼 함수 추가 및 모듈화 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->